### PR TITLE
Update dep handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ InternedStrings = "7d512f48-7fb1-5a58-b986-67e6dc259f01"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]
-Parsers = "^0.2.20"
+Parsers = "^0.2.20, ^0.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 1.0
-DataFrames
-InternedStrings
-Parsers 0.2.20


### PR DESCRIPTION
This deletes `REQUIRE` (as that whole system is now gone) and adds compat with Parsers 0.3. Without the latter change, one can't have the latest version of CSV.jl and CSVReader.jl installed at the same time.

Would be great if you could tag a new release after this is merged! I'd like to rerun https://github.com/davidanthoff/csv-comparison for CSV.jl v0.5, and this is blocking things right now.