### PR TITLE
update deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CSVReader"
 uuid = "6320db66-f659-5b09-9a97-e9f7ce0d36e4"
 authors = ["Tom Kwong <tk3369@gmail.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -10,7 +10,8 @@ Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]
 julia = "1"
-Parsers = "^0.2.20, ^0.3"
+Parsers = "^0.2.20, ^0.3, ^1"
+DataFrames = "^0.19, 0.20"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,8 @@ const iris = "iris.csv"
 function testiris(df)
     @test size(df) == (150, 6)
     @test names(df) == Symbol.(["id", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"])
-    @test unique(df[:Species]) == ["setosa", "versicolor", "virginica"]
-    @test [sum(df[i]) for i in 2:5] ≈ [876.5, 458.6, 563.7, 179.9]
+    @test unique(df[!, :Species]) == ["setosa", "versicolor", "virginica"]
+    @test [sum(df[!, i]) for i in 2:5] ≈ [876.5, 458.6, 563.7, 179.9]
 end
 
 function genperf(rows, nfloat, nstr, strsize, nqfloat, nqstr, qstrsize)
@@ -45,21 +45,21 @@ end
 
         # without headers
         df = reader("iris2.csv"; headers = false) 
-        names!(df, Symbol.(["id", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"]))
+        rename!(df, Symbol.(["id", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"]))
         testiris(df)
 
         # missing data (1st row ok)
         df = reader("missing1.csv") 
-        @test sum(count(ismissing, df[c]) for c in 1:ncol(df)) == 5
+        @test sum(count(ismissing, df[!,c]) for c in 1:ncol(df)) == 5
 
         # missing  data (1st row contains missing, causing column to have type String)
         df = reader("missing2.csv") 
-        @test sum(count(ismissing, df[c]) for c in 1:ncol(df)) == 3
+        @test sum(count(ismissing, df[!,c]) for c in 1:ncol(df)) == 3
 
         # missing  data (1st row contains missing, causing column to have type String)
         # but, this is corrected via parsers spec
         df = reader("missing2.csv", parsers"i:4")
-        @test sum(count(ismissing, df[c]) for c in 1:ncol(df)) == 5
+        @test sum(count(ismissing, df[!,c]) for c in 1:ncol(df)) == 5
     end
 
     # Performance test - generate test files.


### PR DESCRIPTION
The latest versions of other packages (e.g. `CSV`) already require `Parsers` v1. This PR makes possible to keep `CSVReader` and the latest versions of such packages in the same environment.

Compatible versions of `DataFrames` are also added. The lowest bound (0.19) is set to avoid deprecation warnings in the (also updated) tests.

It remains to set suitable compat bounds to `InternedStrings`. I found no specific incompatibility to define them.