### PR TITLE
Update Parsers compat to include v2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 [compat]
 DataFrames = "^0.19, 0.20, 0.21, 0.22"
 InternedStrings = "0.7"
-Parsers = "^0.2.20, ^0.3, ^1"
+Parsers = "^0.2.20, ^0.3, ^1, 2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Nothing changed in the `Parsers.tryparse` contract, so this shouldn't cause any issues.